### PR TITLE
Make pyformance optional.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,11 @@ setup(
     zip_safe=True,
     packages=find_packages(),
     install_requires=[
-        'pyformance>=0.3.1',
         'requests==2.5.3',
     ],
+    extras_require = {
+        'pyformance': ['pyformance>=0.3.1'],
+    },
     classifiers=[],
     url='https://github.com/signalfx/signalfx-python',
 )


### PR DESCRIPTION
I was thinking that pyformance should be an optional dependency. @mpetazzoni, what do you think?