### PR TITLE
Add some dimension support.

### DIFF
--- a/signalfx/__init__.py
+++ b/signalfx/__init__.py
@@ -10,6 +10,10 @@ DEFAULT_API_ENDPOINT_URL = 'https://api.signalfx.com'
 DEFAULT_INGEST_ENDPOINT_URL = 'https://ingest.signalfx.com'
 
 
+class Error(Exception):
+    """Base error class for this module."""
+
+
 class __BaseSignalFx(object):
 
     def __init__(self, api_token=None, api_endpoint=DEFAULT_API_ENDPOINT_URL,

--- a/signalfx/pyformance/__init__.py
+++ b/signalfx/pyformance/__init__.py
@@ -21,11 +21,18 @@ class SignalFxReporter(reporter.Reporter):
     def __init__(self, api_token, url=signalfx.DEFAULT_INGEST_ENDPOINT_URL,
                  registry=None, reporting_interval=1,
                  default_dimensions=None):
+        if (default_dimensions is not None
+                and not isinstance(default_dimensions, dict)):
+            raise signalfx.Error('The default_dimensions argument must be a '
+                                 'dict of string keys to string values.')
+
         reporter.Reporter.__init__(self, registry=registry,
                                    reporting_interval=reporting_interval)
+
         self.default_dimensions = default_dimensions
         if default_dimensions is None:
             self.default_dimensions = {}
+
         self._sfx = signalfx.SignalFx(api_token, ingest_endpoint=url)
 
     def report_now(self, registry=None, timestamp=None):

--- a/signalfx/pyformance/__init__.py
+++ b/signalfx/pyformance/__init__.py
@@ -19,9 +19,13 @@ class SignalFxReporter(reporter.Reporter):
     """
 
     def __init__(self, api_token, url=signalfx.DEFAULT_INGEST_ENDPOINT_URL,
-                 registry=None, reporting_interval=1):
+                 registry=None, reporting_interval=1,
+                 default_dimensions=None):
         reporter.Reporter.__init__(self, registry=registry,
                                    reporting_interval=reporting_interval)
+        self.default_dimensions = default_dimensions
+        if default_dimensions is None:
+            self.default_dimensions = {}
         self._sfx = signalfx.SignalFx(api_token, ingest_endpoint=url)
 
     def report_now(self, registry=None, timestamp=None):
@@ -41,6 +45,11 @@ class SignalFxReporter(reporter.Reporter):
                     'value': value,
                     timestamp: sf_timestamp
                 }
+                if len(self.default_dimensions) > 0:
+                    # TODO(wt): Plumbing in custom dimensions at some point will
+                    # require copying the default dimensions instead of using
+                    # them directly.
+                    info['dimensions'] = self.default_dimensions
                 if submetric == 'count':
                     cumulative_counters.append(info)
                 else:


### PR DESCRIPTION
This change allows default dimensions to be specified for the SignalFx
reporter. The reporter will attach those dimensions to every reported
metric.