### PR TITLE
Fixing a protocol buffer bug for metric:dimensions

### DIFF
--- a/examples/pyformance_usecase.py
+++ b/examples/pyformance_usecase.py
@@ -6,7 +6,6 @@ sys.path.append(os.path.realpath('..'))
 
 import argparse
 import logging
-import os
 import pyformance as pyf
 import signalfx.pyformance
 import time

--- a/signalfx/pyformance/__init__.py
+++ b/signalfx/pyformance/__init__.py
@@ -24,7 +24,7 @@ class SignalFxReporter(reporter.Reporter):
         if (default_dimensions is not None
                 and not isinstance(default_dimensions, dict)):
             raise TypeError('The default_dimensions argument must be a '
-                                 'dict of string keys to string values.')
+                            'dict of string keys to string values.')
 
         reporter.Reporter.__init__(self, registry=registry,
                                    reporting_interval=reporting_interval)

--- a/signalfx/version.py
+++ b/signalfx/version.py
@@ -1,4 +1,4 @@
 # Copyright (C) 2015 SignalFx, Inc. All rights reserved.
 
 name = 'signalfx'
-version = '0.3.3'
+version = '0.3.4'


### PR DESCRIPTION
- protocol buffers weren't handling dimensions very well.
Fixed that and tested with various scenarios.
- Cleanup up imports in examples.