### PR TITLE
Moved the start of send thread and some other refactoring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,32 @@ gauge('test').set_value(42)
 ```
 
 See `examples/pyformance_usecase.py` for a complete code example using Pyformance.
+
+## Known Issues
+
+1. Sending only 1 datapoint and not seeing it in the chart.
+
+Root Cause: The reason you are not seeing the metrics in the chart is because the script that is calling the python client module is exiting right after calling the send method. The python client library is mainly targeted towards sending a continuous stream of metrics and was implemented to be asynchronous.
+
+Workaround:  Adding a sleep [eg: time.sleep(5)] for say 5 secs before exciting from your script or run your script from a python interpreter you should start seeing your metric in the chart. Or if you send a stream or metrics, you will see the metrics in the chart.?add
+
+
+2. SSLError when sending events by calling send_event() method
+
+```python
+ERROR:root:Posting to SignalFx failed.
+Traceback (most recent call last):
+  File "/usr/local/lib/python2.7/dist-packages/signalfx/__init__.py", line 203, in _post
+    response = _session.post(url, data=data, timeout=self._timeout)
+  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 508, in post
+    return self.request('POST', url, data=data, json=json, **kwargs)
+  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 465, in request
+    resp = self.send(prep, **send_kwargs)
+  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 573, in send
+    r = adapter.send(request, **kwargs)
+  File "/usr/local/lib/python2.7/dist-packages/requests/adapters.py", line 431, in send
+    raise SSLError(e, request=request)
+SSLError: hostname 'api.signalfx.com' doesn't match either of '*.signalfuse.com', 'signalfuse.com'
+```
+
+Solution: Please upgrade to python version 2.7.8, 2.7.9 or 2.7.10.

--- a/README.md
+++ b/README.md
@@ -102,19 +102,8 @@ Workaround:  Adding a sleep [eg: time.sleep(5)] for say 5 secs before exciting f
 
 #### SSLError when sending events by calling send_event() method
 
-```python
+```
 ERROR:root:Posting to SignalFx failed.
-Traceback (most recent call last):
-  File "/usr/local/lib/python2.7/dist-packages/signalfx/__init__.py", line 203, in _post
-    response = _session.post(url, data=data, timeout=self._timeout)
-  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 508, in post
-    return self.request('POST', url, data=data, json=json, **kwargs)
-  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 465, in request
-    resp = self.send(prep, **send_kwargs)
-  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 573, in send
-    r = adapter.send(request, **kwargs)
-  File "/usr/local/lib/python2.7/dist-packages/requests/adapters.py", line 431, in send
-    raise SSLError(e, request=request)
 SSLError: hostname 'api.signalfx.com' doesn't match either of '*.signalfuse.com', 'signalfuse.com'
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,15 @@ Python-based metric collections tools or libraries.
 
 ## Installation
 
+To install from pip:
 ```
 pip install signalfx
+```
+To install from source:
+```
+git clone https://github.com/signalfx/signalfx-python.git
+cd signalfx-python
+python setup.py install
 ```
 
 ## Usage
@@ -97,7 +104,7 @@ See `examples/pyformance_usecase.py` for a complete code example using Pyformanc
 
 Root Cause: The reason you are not seeing the metrics in the chart is because the script that is calling the python client module is exiting right after calling the send method. The python client library is mainly targeted towards sending a continuous stream of metrics and was implemented to be asynchronous.
 
-Workaround:  Adding a sleep [eg: time.sleep(5)] for say 5 secs before exciting from your script or run your script from a python interpreter you should start seeing your metric in the chart. Or if you send a stream or metrics, you will see the metrics in the chart.?add
+Workaround:  Adding a sleep `eg: time.sleep(5)` for say 5 secs before exciting from your script or run your script from a python interpreter you should start seeing your metric in the chart. Or if you send a stream or metrics, you will see the metrics in the chart.
 
 
 #### SSLError when sending events by calling send_event() method
@@ -106,5 +113,6 @@ Workaround:  Adding a sleep [eg: time.sleep(5)] for say 5 secs before exciting f
 ERROR:root:Posting to SignalFx failed.
 SSLError: hostname 'api.signalfx.com' doesn't match either of '*.signalfuse.com', 'signalfuse.com'
 ```
+Root Cause: SignalFx API endpoints server has SNI enabled and the urllib3 module in python versions prior to 2.7.8 had a bug that causes the above issue. This was fixed in later versions of python.
 
-Solution: Please upgrade to python version 2.7.8, 2.7.9 or 2.7.10.
+Solution: Please upgrade to python version 2.7.9 or 2.7.10.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ to interact with SignalFx or report metric and event data to SignalFx.
 It is also the base for metric reporters that integrate with common
 Python-based metric collections tools or libraries.
 
+
 ## Installation
 
 ```
@@ -89,16 +90,17 @@ gauge('test').set_value(42)
 
 See `examples/pyformance_usecase.py` for a complete code example using Pyformance.
 
+
 ## Known Issues
 
-1. Sending only 1 datapoint and not seeing it in the chart.
+#### Sending only 1 datapoint and not seeing it in the chart.
 
 Root Cause: The reason you are not seeing the metrics in the chart is because the script that is calling the python client module is exiting right after calling the send method. The python client library is mainly targeted towards sending a continuous stream of metrics and was implemented to be asynchronous.
 
 Workaround:  Adding a sleep [eg: time.sleep(5)] for say 5 secs before exciting from your script or run your script from a python interpreter you should start seeing your metric in the chart. Or if you send a stream or metrics, you will see the metrics in the chart.?add
 
 
-2. SSLError when sending events by calling send_event() method
+#### SSLError when sending events by calling send_event() method
 
 ```python
 ERROR:root:Posting to SignalFx failed.

--- a/signalfx/version.py
+++ b/signalfx/version.py
@@ -1,4 +1,4 @@
 # Copyright (C) 2015 SignalFx, Inc. All rights reserved.
 
 name = 'signalfx'
-version = '0.3.4'
+version = '0.3.5'


### PR DESCRIPTION
- Refactored to have send thread started only when send is called.
  Without this the send queue wasn't picking up metrics put into
  the queue. This was found when trying to use the py_client for
  the diamond handler as diamond was spawning different python processses.
- Refactored arguments being passed by multiple classes.
- Added lock() for the flag that checks thread running status.
  This is to avoid issues caused by multple threads calling the
  send method.
- Added Known Issues and workaround in the README