### PR TITLE
Fix a protobuf bug with metric_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,32 @@ sfx.send(
     counters=[
       {'metric': 'myfunc.calls', 'value': 42},
       ...
+    ],
+    cumulative_counters=[
+      {'metric': 'myfunc.calls_cumulative', 'value': 10},
+      ...
     ])
 ```
-Multi-Dimensional reproting data: 
+
+Reporting Dimensions for the data is optional and can be accomplished as follows:
+
 ```python
 import signalfx
 
 sfx = signalfx.SignalFx('MY_TOKEN')
 sfx.send(
     gauges=[
-        {'metric': 'myfunc.time', 'value': 532, 'dimensions': {'host': 'server1', 'host_ip': '1.2.3.4'},
-        ...
-        ])
+      {'metric': 'myfunc.time', 'value': 532, 'dimensions': {'host': 'server1', 'host_ip': '1.2.3.4'}},
+      ...
+    ],
+    counters=[
+      {'metric': 'myfunc.calls', 'value': 42, 'dimensions': {'host': 'server1', 'host_ip': '1.2.3.4'}},
+      ...
+    ],
+    cumulative_counters=[
+      {'metric': 'myfunc.calls_cumulative', 'value': 10, 'dimensions': {'host': 'server1', 'host_ip': '1.2.3.4'}},
+      ...
+    ])
 ```
 
 See `examples/generic_usecase.py` for a complete code example for Reporting data.

--- a/signalfx/__init__.py
+++ b/signalfx/__init__.py
@@ -223,12 +223,10 @@ class ProtoBufSignalFx(SignalFxClient):
     def _add_to_queue(self, metric_type, datapoint):
         pbuf_dp = sf_pbuf.DataPoint()
         self._assign_value_type(pbuf_dp, datapoint['value'])
+        pbuf_dp.metricType = getattr(sf_pbuf, metric_type.upper())
         pbuf_dp.metric = datapoint['metric']
         if datapoint.get('timestamp'):
             pbuf_dp.timestamp = int(datapoint['timestamp'])
-        if datapoint.get('metric_type'):
-            pbuf_dp.metricType = getattr(
-                sf_pbuf, datapoint['metric_type'].upper())
         self._set_datapoint_dimensions(
             pbuf_dp, datapoint.get('dimensions', {}))
         self._queue.put(pbuf_dp)

--- a/signalfx/version.py
+++ b/signalfx/version.py
@@ -1,4 +1,4 @@
 # Copyright (C) 2015 SignalFx, Inc. All rights reserved.
 
 name = 'signalfx'
-version = '0.3.5'
+version = '0.3.6'


### PR DESCRIPTION
- When sending data using protobuf, counters and
  cumulative_counters were being sent as gauge.
- Updated README.md and version