### PR TITLE
More Python3 fixes, and run tests with Tox instead of Circle overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
-*.dist/
-*.build/
 *.pyc
+
+/.tox/
+/build/
+/dist/
+/*.egg-info/
+
+# IDE files
+.project/
 .ropeproject/
-*.egg-info/
 .idea/
-build/
-dist/

--- a/circle.yml
+++ b/circle.yml
@@ -1,21 +1,4 @@
-machine:
-  python:
-    version: 2.7.9
-
 dependencies:
   pre:
-    - pip install --upgrade pip
-    - pip install --upgrade flake8 setuptools flake8 pytest mock funcsigs
-    - pip install -r requirements.txt
-    - pip uninstall -y signalfx || true
-    - pip install .
-
-test:
-  pre:
-    - flake8 signalfx/*.py
-    - flake8 signalfx/signalflow/*.py
-    - flake8 signalfx/pyformance/*.py
-    - flake8 examples/*.py
-  override:
-    - python tests/test_data_reporting.py
-    - python tests/live_tests.py --metric_name 'MET' --tag_name 'TG' --key 'K' --value 'V'
+    - pip install --upgrade pip tox tox-pyenv
+    - pyenv local 2.7.9 3.4.2

--- a/signalfx/ingest.py
+++ b/signalfx/ingest.py
@@ -118,7 +118,7 @@ class _BaseSignalFxIngestClient(object):
         }
         logging.debug('Sending datapoints to SignalFx: %s', data)
 
-        for metric_type, datapoints in data.iteritems():
+        for metric_type, datapoints in data.items():
             if not datapoints:
                 continue
             if not isinstance(datapoints, list):
@@ -338,7 +338,8 @@ class JsonSignalFxIngestClient(_BaseSignalFxIngestClient):
     def _batch_data(self, datapoints_list):
         datapoints = collections.defaultdict(list)
         for item in datapoints_list:
-            datapoints[item.keys()[0]].append(item[item.keys()[0]])
+            item_keys = list(item.keys())
+            datapoints[item_keys[0]].append(item[item_keys[0]])
         return json.dumps(datapoints)
 
     def _send_event(self, event_data=None, url=None, session=None):

--- a/tests/live_tests.py
+++ b/tests/live_tests.py
@@ -32,11 +32,16 @@ parser.add_argument('--key')
 parser.add_argument('--value')
 args = parser.parse_args()
 
-if not args.token: args.token = os.environ['SIGNALFX_API_TOKEN']
-if not args.metric_name: args.metric_name = 'fake..metric_to_"test'
-if not args.tag_name: args.tag_name = '"fake_tag_name"~'
-if not args.key: args.key = 'fake_key"%'
-if not args.value: args.value = 'fake_value'
+if not args.token:
+    args.token = os.environ['SIGNALFX_API_TOKEN']
+if not args.metric_name:
+    args.metric_name = 'fake..metric_to_"test'
+if not args.tag_name:
+    args.tag_name = '"fake_tag_name"~'
+if not args.key:
+    args.key = 'fake_key"%'
+if not args.value:
+    args.value = 'fake_value'
 
 FAKE_METRIC_NAME, FAKE_TAG, FAKE_KEY, FAKE_VALUE = \
     args.metric_name, args.tag_name, args.key, args.value
@@ -48,6 +53,7 @@ sD, uD, gD = 'search_dimensions', 'update_dimension', 'get_dimension'
 sfx = signalfx.SignalFx().rest(TOKEN)
 CLIENT_NAME = 'sfx'
 
+
 def test_func(client_name, func_name, sleep_time=5, msg='is being tested!',
               func_args=None, **kwargs):
     return_value = None
@@ -55,18 +61,20 @@ def test_func(client_name, func_name, sleep_time=5, msg='is being tested!',
         try:
             func = eval(client_name + '.' + func_name)
             return_value = func(*func_args, **kwargs)
-            print func_name, msg, '\n', return_value, '\n'
+            print('{} {} -> {}'.format(func_name, msg, return_value))
             time.sleep(sleep_time)
-        except requests.exceptions.HTTPError, e:
-            print func_name, e.message
+        except requests.exceptions.HTTPError as e:
+            print('{} -! {}'.format(func_name, e))
     else:
-        print func_name, 'not available'
+        print('{} is not available'.format(func_name))
     return return_value
 
+
 def apply_sequence(client_name, sequence, f_args, seq_msg=None, **kwargs):
-    print sequence, 'expected behavior is', seq_msg
+    print('{} expected behavior is {}'.format(sequence, seq_msg))
     for item in sequence:
         test_func(client_name, item, func_args=f_args, **kwargs)
+
 
 def main():
     apply_sequence(CLIENT_NAME, [gT, sT, dT, uT, gT, sT, dT, gT, sT, uT,
@@ -81,7 +89,7 @@ def main():
     test_func(CLIENT_NAME, 'update_metric_by_name',
               func_args=[FAKE_METRIC_NAME, 'gauge'], timeout=15)
     r = test_func(CLIENT_NAME, 'search_metric_time_series',
-              func_args=[FAKE_METRIC_NAME], timeout=15)
+                  func_args=[FAKE_METRIC_NAME], timeout=15)
     if r:
         if len(r['results']) > 0:
             mts_id = r['results'][0]['id']

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,23 @@
+[test]
+envlist = py27,py34,flake8
+
+[testenv]
+usedevelop = True
+passenv = ORG_NAME_FOR_SIGNALFX_API_TOKEN_IS_SFx_Test SIGNALFX_API_TOKEN
+deps = -r{toxinidir}/requirements.txt
+commands = python tests/test_data_reporting.py
+           python tests/live_tests.py --metric_name 'MET' --tag_name 'TG' --key 'K' --value 'V'
+
+[testenv:flake8]
+commands = flake8 signalfx/*.py
+           flake8 signalfx/signalflow/*.py
+           flake8 signalfx/pyformance/*.py
+           flake8 examples/*.py
+deps = flake8
+
+[testenv:py27]
+basepython = python2.7
+
+[testenv:py34]
+basepython = python3.4
+install_command = pip3 install {opts} {packages}


### PR DESCRIPTION
Some more Python 3 fixes, with same changes to how we run tests so we can actually run tests with both Python 2.x and Python 3.x and catch those Python 2/3 compatibility issues better in the future.