### PR TITLE
Allow long metric values and property values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 This file documents important changes to the SignalFx Python client library.
 
+- [[1.0.11]- 2016-11-22: Long values support](#1011---2016-11-22-long-values-support)
 - [[1.0.10]- 2016-11-21: Unicode event properties fix](#1010---2016-11-21-unicode-event-properties-fix)
 - [[1.0.9] - 2016-10-26: Datapoints queue draining fix](#109---2016-10-26-datapoints-queue-draining-fix)
 - [[1.0.8] - 2016-10-20: A missing field from events](#108---2016-10-20-a-missing-field-from-events)
 - [[1.0.7] - 2016-10-05: More Python 3 compatibility](#107---2016-10-05-more-python-3-compatibility)
 - [[1.0.5] - 2016-09-29: Python 3 compatibility](#105---2016-09-29-python-3-compatibility)
 - [[1.0.1] - 2016-06-02: Support for SignalFlow API](#101---2016-06-02-support-for-signalflow-api)
+
+#### [1.0.11] - 2016-11-21: Long value support
+long type metric values were previously unsupported.  This release
+allows long values less than or equal to 9223372036854775807.
 
 #### [1.0.10] - 2016-11-21: Unicode event properties fix
 Unicode strings were previously unsupported for event properties.  This release

--- a/signalfx/ingest.py
+++ b/signalfx/ingest.py
@@ -274,12 +274,18 @@ class ProtoBufSignalFxIngestClient(_BaseSignalFxIngestClient):
     def _assign_property_value(self, prop, value):
         if isinstance(value, int):
             prop.value.intValue = value
+        elif isinstance(value, long):
+            if value > 9223372036854775807:
+                raise ValueError('Invalid Value ' + str(value) +
+                                 ' exceeds maximum signed 64 bit integer' +
+                                 ' (9223372036854775807)')
+            prop.value.intValue = value
+        elif isinstance(value, float):
+            prop.value.doubleValue = value
         elif isinstance(value, str):
             prop.value.strValue = value
         elif isinstance(value, unicode):
             prop.value.strValue = value
-        elif isinstance(value, float):
-            prop.value.doubleValue = value
         elif isinstance(value, bool):
             prop.value.boolValue = value
         else:
@@ -288,12 +294,18 @@ class ProtoBufSignalFxIngestClient(_BaseSignalFxIngestClient):
     def _assign_value_type(self, pbuf_dp, value):
         if isinstance(value, int):
             pbuf_dp.value.intValue = value
+        elif isinstance(value, long):
+            if value > 9223372036854775807:
+                raise ValueError('Invalid Value ' + str(value) +
+                                 ' exceeds maximum signed 64 bit integer' +
+                                 ' (9223372036854775807)')
+            pbuf_dp.value.intValue = value
+        elif isinstance(value, float):
+            pbuf_dp.value.doubleValue = value
         elif isinstance(value, str):
             pbuf_dp.value.strValue = value
         elif isinstance(value, unicode):
             pbuf_dp.value.strValue = value
-        elif isinstance(value, float):
-            pbuf_dp.value.doubleValue = value
         else:
             raise ValueError('Invalid Value ' + str(value))
 

--- a/signalfx/version.py
+++ b/signalfx/version.py
@@ -1,4 +1,4 @@
 # Copyright (C) 2015-2016 SignalFx, Inc. All rights reserved.
 
 name = 'signalfx'
-version = '1.0.10'
+version = '1.0.11'


### PR DESCRIPTION
Allow long values to be dispatched as long as they are less than or equal to a natural int64