### PR TITLE
Added context managers to SignalFlowClient()

### DIFF
--- a/signalfx/signalflow/__init__.py
+++ b/signalfx/signalflow/__init__.py
@@ -19,6 +19,12 @@ class SignalFlowClient(object):
         self._transport = transport(token, endpoint, timeout)
         self._computations = set([])
 
+    def __exit__(self):
+        return self.close()
+    
+    def __del__(self):
+        return self.close()
+        
     def _get_params(self, **kwargs):
         return dict((k, v) for k, v in kwargs.items() if v)
 


### PR DESCRIPTION
Context managers can help ensure a safe transport closure while having a sleeker usage:

```
    with signalfx.SignalFx().signalflow(S_API_KEY) as sf:
        for msg in sf.execute(program).stream():
            if not isinstance(msg, signalfx.signalflow.messages.DataMessage):
                continue
            print('{}: {}'.format(msg.logical_timestamp_ms, msg.data))
```