### PR TITLE
Fix MANIFEST.in so signalfx is installable from source

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include requirements.txt
 include README.md
 include LICENSE


### PR DESCRIPTION
Super minor, I wouldn't surprise if this doesn't get merged.   It does enable the following to work though:

```
python setup.py sdist
cd dist
virtualenv venv
venv/bin/pip install *.tar.gz
```