### PR TITLE
difference time series on client instead of using rateofchange() signalflow

### DIFF
--- a/examples/signalflow/dataframe.py
+++ b/examples/signalflow/dataframe.py
@@ -27,6 +27,10 @@ def get_data_frame(client, program, start, stop, resolution=None):
     data = {}
     metadata = {}
 
+    is_rateofchange = '.rateofchange()' in program
+    if is_rateofchange:
+        program = program.replace('.rateofchange()', '')
+
     c = client.execute(program, start=start, stop=stop, resolution=resolution)
     for msg in c.stream():
         if isinstance(msg, messages.DataMessage):
@@ -38,6 +42,8 @@ def get_data_frame(client, program, start, stop, resolution=None):
             metadata[msg.tsid] = msg.properties
 
     df = pandas.DataFrame.from_dict(data, orient='index')
+    if is_rateofchange:
+        df = df.diff()
     df.metadata = metadata
     return df
 


### PR DESCRIPTION
This is a somewhat subtle nuance, which wasn't very obvious to me when I was playing with this.

If your data is a monotonically increasing counter and you want a rate of change, in signalflow you can use ```rateofchange()```. It works, however, by differencing the time series at Signalfx's internal storage resolution - and resolution you pass to ```get_data_frame()``` will only affect the frequency of datapoints returned.

From analysis perspective, however, it's not what you typically would want. Usually, if you set resolution to 1 minute, you want time series to be minutely. Or if you set resolution to 10 minutes, you want a time series whose adjacent datapoints are 10 minutes apart - and you want values for entire 10 minute period, not signalfx's internal resolution.

To make this happen, we get raw ```'rollup', 'count'``` data and difference it on the client thus getting the result that we need.

Hope I am explaining it correctly.