### PR TITLE
Adds a human-readable reason to WebSocketTransport's close

### DIFF
--- a/signalfx/signalflow/ws.py
+++ b/signalfx/signalflow/ws.py
@@ -282,7 +282,10 @@ class WebSocketTransport(transport._SignalFlowTransport, WebSocketClient):
         denotes a normal close; all others are errors."""
         if code != 1000:
             self._error = errors.SignalFlowException(code, reason)
-            _logger.info('Lost WebSocket connection with %s (%s).', self, code)
+            _logger.info('Lost WebSocket connection with %s (%s: %s).',
+                    self,
+                    code,
+                    reason)
             for c in self._channels.values():
                 c.offer(WebSocketComputationChannel.END_SENTINEL)
         self._channels.clear()


### PR DESCRIPTION
This turns "`Lost WebSocket connection with wss://{url} (1006)`" into "`Lost WebSocket connection with wss://{url} (1006: Gone Away)`"