### PR TITLE
Updated default timeout

### DIFF
--- a/signalfx/constants.py
+++ b/signalfx/constants.py
@@ -5,7 +5,7 @@ DEFAULT_INGEST_ENDPOINT = 'https://ingest.signalfx.com'
 DEFAULT_API_ENDPOINT = 'https://api.signalfx.com'
 DEFAULT_STREAM_ENDPOINT = 'https://stream.signalfx.com'
 DEFAULT_BATCH_SIZE = 300  # Will wait for this many requests before posting
-DEFAULT_TIMEOUT = 1
+DEFAULT_TIMEOUT = 5
 
 # Integer Boundaries
 INTEGER_MAX = (2**63)-1


### PR DESCRIPTION
Changed default timeout value to 5 seconds so that it matches the Go library.