### PR TITLE
signalflow: add support for immediate computations

### DIFF
--- a/signalfx/signalflow/__init__.py
+++ b/signalfx/signalflow/__init__.py
@@ -29,12 +29,13 @@ class SignalFlowClient(object):
         return dict((k, v) for k, v in kwargs.items() if v)
 
     def execute(self, program, start=None, stop=None, resolution=None,
-                max_delay=None, persistent=False):
+                max_delay=None, persistent=False, immediate=False):
         """Execute the given SignalFlow program and stream the output back."""
         params = self._get_params(start=start, stop=stop,
                                   resolution=resolution,
                                   maxDelay=max_delay,
-                                  persistent=persistent)
+                                  persistent=persistent,
+                                  immediate=immediate)
 
         def exec_fn(since=None):
             if since:


### PR DESCRIPTION
When immediate is set to true, the stop time will be automatically adjusted to allow for the immediate
delivery of the computation output.

Test Plan: wrote a small python script using the library and verified
the setting was picked up. This is a non breaking change.