### PR TITLE
fix boolean check on parameter values

### DIFF
--- a/signalfx/signalflow/__init__.py
+++ b/signalfx/signalflow/__init__.py
@@ -26,7 +26,7 @@ class SignalFlowClient(object):
         return self.close()
 
     def _get_params(self, **kwargs):
-        return dict((k, v) for k, v in kwargs.items() if v)
+        return dict((k, v) for k, v in kwargs.items() if v is not None)
 
     def execute(self, program, start=None, stop=None, resolution=None,
                 max_delay=None, persistent=False, immediate=False):


### PR DESCRIPTION
The previous check "(k, v)  ... if v" excludes pairs with v=0 or v=False, but we may want to send these. Now we exclude pairs with v=None only.