### PR TITLE
generate AWSUniqueId via ECS metadata service

### DIFF
--- a/signalfx/aws.py
+++ b/signalfx/aws.py
@@ -28,26 +28,41 @@ import logging
 import requests
 
 AWS_ID_DIMENSION = 'AWSUniqueId'
-AWS_ID_URL = 'http://169.254.169.254/latest/dynamic/instance-identity/document'
 DEFAULT_AWS_TIMEOUT = 1  # Timeout to connect to the AWS metadata service
+
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
+EC2_ID_URL = 'http://169.254.169.254/latest/dynamic/instance-identity/document'
+# https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html
+ECS_METADATA_URL = '169.254.170.2/v2/metadata'
 
 _logger = logging.getLogger(__name__)
 
 
 def get_aws_unique_id(timeout=DEFAULT_AWS_TIMEOUT):
-    """Determine the current AWS unique ID
+    """Determine the current AWS unique ID by trying the ECS metadata service
+    and then the EC2 metadata service.
 
     Args:
-        timeout (int): How long to wait for a response from AWS metadata IP
+        timeout (int): How long to wait for a response from AWS metadata service
     """
     try:
-        resp = requests.get(AWS_ID_URL, timeout=timeout).json()
-    except requests.exceptions.ConnectTimeout:
-        _logger.warning('Connection timeout when determining AWS unique '
-                        'ID. Not using AWS unique ID.')
-        return None
-    else:
-        aws_id = "{0}_{1}_{2}".format(resp['instanceId'], resp['region'],
-                                      resp['accountId'])
-        _logger.debug('Using AWS unique ID %s.', aws_id)
-        return aws_id
+        resp = requests.get(ECS_METADATA_URL, timeout=timeout)
+        # ECS metadata service returns a 400 (HTTPError)
+        # if we're not an ECS task
+        resp.raise_for_status()
+        task_arn = resp.json()['TaskARN']
+        # arn:aws:ecs:region:account-id:task/task-id
+        [_, _, _, region, account_id, task] = task_arn.split(':', 6)
+        task_id = task.split('/', 1)[1]
+        aws_id = '{0}_{1}_{2}'.format(task_id, region, account_id)
+    except (requests.exceptions.HTTPError, requests.exceptions.ConnectTimeout):
+        try:
+            data = requests.get(EC2_ID_URL, timeout=timeout).json()
+        except requests.exceptions.ConnectTimeout:
+            _logger.warning('Connection timeout when determining AWS unique '
+                            'ID. Not using AWS unique ID.')
+            return None
+        aws_id = '{0}_{1}_{2}'.format(data['instanceId'], data['region'],
+                                      data['accountId'])
+    _logger.debug('Using AWS unique ID %s.', aws_id)
+    return aws_id


### PR DESCRIPTION
for ECS containers, getting the EC2 instance ID as our unique ID is unhelpful. try the [ECS task metadata service](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html) first and, if that fails, then fall back to the EC2 metadata service