### PR TITLE
test against py37

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: python
-python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
+matrix:
+  include:
+  - python: "2.7"
+  - python: "3.5"
+  - python: "3.6"
+  - python: "3.7"
+    dist: xenial
+  - python: 3.8-dev
+    dist: xenial
+  - python: "pypy"
 install: "pip install tox tox-travis"
 script: tox
 sudo: false


### PR DESCRIPTION
I noticed that the tests were not running against the latest python versions. I think that the `tox.ini` might need updated too so Ill take a look at this after seeing a CI run.