### PR TITLE
Fixing size key references when returning limited timeseries

### DIFF
--- a/signalfx/signalflow/computation.py
+++ b/signalfx/signalflow/computation.py
@@ -213,8 +213,8 @@ class Computation(object):
             self._find_matched_no_timeseries = True
         elif message['messageCode'] == 'FIND_LIMITED_RESULT_SET':
             self._find_limited_resultset = True
-            self._find_matched_size = message['matchedSize']
-            self._find_limit_size = message['limitSize']
+            self._find_matched_size = message['contents']['matchedSize']
+            self._find_limit_size = message['contents']['limitSize']
         elif message['messageCode'] == 'GROUPBY_MISSING_PROPERTY':
             self._group_by_missing_property = True
             self._group_by_missing_properties = message['propertyNames']


### PR DESCRIPTION
https://github.com/signalfx/signalfx-python/issues/85#issue-491953245
As per my experience and above issue, the _process_info_message function had incorrect keys when referencing matchedSize and limitSize when a function is executed that exceeds the timeseries limitation for your account.