### PR TITLE
Add python version classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,12 @@ setup(
     classifiers=[
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     url='https://github.com/signalfx/signalfx-python',
 )


### PR DESCRIPTION
This will add Python version classifiers to the package, so that PyPI and tools like [`caniusepython3`](https://github.com/brettcannon/caniusepython3#how-do-you-tell-if-a-project-has-been-ported-to-python-3) will acknowledge the work you've put into supporting those versions in recent updates :)

I'm not sure if you need to bump the package version as well for the classifiers to be added on PyPI (They'll show up in the bottom-left of the sidebar here: https://pypi.org/project/signalfx/) but I think you can just re-publish this commit under the same version number if you prefer.

Here is the current behavior of `caniusepython3` comparing this package to `requests` - it's easy for us to override `signalfx` in that tool but I wanted to submit this PR while it was top of mind.

```
$ python3 --version
Python 3.7.7
$ python3 -m venv venv
$ . venv/bin/activate
$ pip install caniusepython3 requests signalfx
$ caniusepython3 --projects signalfx requests
Finding and checking dependencies ...

You need 1 project to transition to Python 3.
Of that 1 project, 1 has no direct dependencies blocking its transition:

  signalfx
```

Thank you for providing and maintaining this package!