### PR TITLE
Fix bad arguments to underlying _get for detector info

### DIFF
--- a/signalfx/rest.py
+++ b/signalfx/rest.py
@@ -525,7 +525,6 @@ class SignalFxRestClient(object):
         """
         resp = self._get(
             self._u(self._DETECTOR_ENDPOINT_SUFFIX, detector_id, 'events'),
-            None,
             **kwargs
         )
         resp.raise_for_status()
@@ -539,7 +538,6 @@ class SignalFxRestClient(object):
         """
         resp = self._get(
             self._u(self._DETECTOR_ENDPOINT_SUFFIX, detector_id, 'incidents'),
-            None,
             **kwargs
         )
         resp.raise_for_status()


### PR DESCRIPTION
# Summary
Fix errors when passing args to `get_detector_*` methods.

# Motivation
Invoking `get_detector_events` fails when providing any of the `**kwargs` that `_get` supports, because I accidentally plopped a `None` in the argument list that shouldn't be there.