### PR TITLE
fix signalfx.aws.get_aws_unique_id()

### DIFF
--- a/signalfx/aws.py
+++ b/signalfx/aws.py
@@ -33,7 +33,7 @@ DEFAULT_AWS_TIMEOUT = 1  # Timeout to connect to the AWS metadata service
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
 EC2_ID_URL = 'http://169.254.169.254/latest/dynamic/instance-identity/document'
 # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html
-ECS_METADATA_URL = '169.254.170.2/v2/metadata'
+ECS_METADATA_URL = 'http://169.254.170.2/v2/metadata'
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Probably something changed in requests library which is now causing any
invocation of `get_aws_unique_id()` to fail with `MissingSchema` exception:

```
>>> import signalfx
>>> import signalfx.aws
>>> signalfx.aws.get_aws_unique_id()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/signalfx/aws.py", line 49, in get_aws_unique_id
    resp = requests.get(ECS_METADATA_URL, timeout=timeout)
  File "/Users/wlopata/Library/Python/2.7/lib/python/site-packages/requests/api.py", line 75, in get
    return request('get', url, params=params, **kwargs)
  File "/Users/wlopata/Library/Python/2.7/lib/python/site-packages/requests/api.py", line 60, in request
    return session.request(method=method, url=url, **kwargs)
  File "/Users/wlopata/Library/Python/2.7/lib/python/site-packages/requests/sessions.py", line 519, in request
    prep = self.prepare_request(req)
  File "/Users/wlopata/Library/Python/2.7/lib/python/site-packages/requests/sessions.py", line 462, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "/Users/wlopata/Library/Python/2.7/lib/python/site-packages/requests/models.py", line 313, in prepare
    self.prepare_url(url, params)
  File "/Users/wlopata/Library/Python/2.7/lib/python/site-packages/requests/models.py", line 387, in prepare_url
    raise MissingSchema(error)
requests.exceptions.MissingSchema: Invalid URL '169.254.170.2/v2/metadata': No schema supplied. Perhaps you meant http://169.254.170.2/v2/metadata?
```

This commit fixes it, at least for EC2 environment. I didn't test it on ECS,
but for sure this commit doesn't make it worse there.