### PR TITLE
Fix reconnection

### DIFF
--- a/signalfx/ingest.py
+++ b/signalfx/ingest.py
@@ -302,6 +302,12 @@ class ProtoBufSignalFxIngestClient(_BaseSignalFxIngestClient):
             'Content-Type': 'application/x-protobuf'
         })
 
+    def _reconnect(self):
+        super(ProtoBufSignalFxIngestClient, self)._reconnect()
+        self._session.headers.update({
+            'Content-Type': 'application/x-protobuf'
+        })
+
     def _add_to_queue(self, metric_type, datapoint):
         pbuf_dp = sf_pbuf.DataPoint()
         self._assign_value(pbuf_dp, datapoint['value'])
@@ -401,6 +407,12 @@ class JsonSignalFxIngestClient(_BaseSignalFxIngestClient):
 
     def __init__(self, token, **kwargs):
         super(JsonSignalFxIngestClient, self).__init__(token, **kwargs)
+        self._session.headers.update({
+            'Content-Type': 'application/json',
+        })
+
+    def _reconnect(self):
+        super(JsonSignalFxIngestClient, self)._reconnect()
         self._session.headers.update({
             'Content-Type': 'application/json',
         })


### PR DESCRIPTION
Reconnection creates a new session. The new session will need these headers re-set on them.

If you don't, then the client will not send a Content-Type after _reconnect and the protobuf client will get 400's