### PR TITLE
signalflow - Default to None for withDerivedMetadata and resolutionAdjustable

### DIFF
--- a/signalfx/signalflow/__init__.py
+++ b/signalfx/signalflow/__init__.py
@@ -33,8 +33,8 @@ class SignalFlowClient(object):
 
     def execute(self, program, start=None, stop=None, resolution=None,
                 max_delay=None, persistent=False, immediate=False,
-                disable_all_metric_publishes=None, withDerivedMetadata=False,
-                resolutionAdjustable=False):
+                disable_all_metric_publishes=None, withDerivedMetadata=None,
+                resolutionAdjustable=None):
         """Execute the given SignalFlow program and stream the output back."""
         params = self._get_params(
                 start=start, stop=stop, resolution=resolution,


### PR DESCRIPTION
These should not be sent unless expressly set.