### PR TITLE
configurable log level via SIGNALFX_LOGLEVEL

### DIFF
--- a/signalfx/__init__.py
+++ b/signalfx/__init__.py
@@ -39,6 +39,7 @@ in-depth examples.
 # Copyright (C) 2015-2017 SignalFx, Inc. All rights reserved.
 
 import logging
+import os
 import requests
 
 from .constants import DEFAULT_API_ENDPOINT, DEFAULT_INGEST_ENDPOINT, \
@@ -53,7 +54,7 @@ __all__ = ['SignalFx']
 __version__ = version.version
 
 _logger = logging.getLogger(__name__)
-
+_logger.setLevel(os.getenv('SIGNALFX_LOGLEVEL', 'INFO').upper())
 
 class SignalFx(object):
     """SignalFx client.


### PR DESCRIPTION
👋 

as the title says, this change adds support for a configurable log level via a `SIGNALFX_LOGLEVEL` environment variable.

while using the [`sfx-sync-detectors`](https://github.com/signalfx/signalfx-detector-syncer) utility to validate detectors, useful context from the `https://api.signalfx.com/v2/detector/validate` API is lost in translation. for example:

```
Validating detectors in <dir> with scope <dir>
2021-03-05 11:00:09,028 |     INFO | Loading detectors from <dir>...
2021-03-05 11:00:09,032 |     INFO | Loaded 2 detector(s) from <dir>.
2021-03-05 11:00:09,457 |     INFO | Found 1 detector(s) from sync in SignalFx.
2021-03-05 11:00:09,457 |     INFO | Status: 1 new, 1 in common (1 updated), 0 removed.
2021-03-05 11:00:09,457 |     INFO | Validating new detector detector.yaml...
Traceback (most recent call last):
  File "<snip>/bin/sfx-sync-detectors", line 8, in <module>
    sys.exit(main())
  File "<snip>/lib/python3.9/site-packages/signalfx_detector_syncer/__main__.py", line 49, in main
    client.sync(options.directory)
  File "<snip>/lib/python3.9/site-packages/signalfx_detector_syncer/syncer.py", line 72, in sync
    self.create_detector(path, from_files[path])
  File "<snip>/lib/python3.9/site-packages/signalfx_detector_syncer/syncer.py", line 175, in create_detector
    self._client.validate_detector(detector)
  File "<snip>/lib/python3.9/site-packages/signalfx/rest.py", line 476, in validate_detector
    resp.raise_for_status()
  File "<snip>/lib/python3.9/site-packages/requests/models.py", line 941, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://api.signalfx.com/v2/detector/validate
```

with this change and an `export SIGNALFX_LOGLEVEL=debug`, the debug logs contain the message returned from the API:
```
<snip>
...
2021-03-05 11:03:48,963 |     INFO | Found 1 detector(s) from sync in SignalFx.
2021-03-05 11:03:48,963 |     INFO | Status: 1 new, 1 in common (1 updated), 0 removed.
2021-03-05 11:03:48,964 |     INFO | Validating new detector detector.yaml...
2021-03-05 11:03:48,964 |    DEBUG | POST https://api.signalfx.com/v2/detector/validate: <payload>
2021-03-05 11:03:49,067 |    DEBUG | Posting to SignalFx failed (400): {
  "code" : 400,
  "message" : "A detect label found in a rule ('<rule>') wasn't found within the program text."
}
Traceback (most recent call last):
  File "<snip>/bin/sfx-sync-detectors", line 8, in <module>
    sys.exit(main())
  File "<snip>/lib/python3.9/site-packages/signalfx_detector_syncer/__main__.py", line 49, in main
    client.sync(options.directory)
  File "<snip>/lib/python3.9/site-packages/signalfx_detector_syncer/syncer.py", line 72, in sync
    self.create_detector(path, from_files[path])
  File "<snip>/lib/python3.9/site-packages/signalfx_detector_syncer/syncer.py", line 175, in create_detector
    self._client.validate_detector(detector)
  File "<snip>/lib/python3.9/site-packages/signalfx/rest.py", line 476, in validate_detector
    resp.raise_for_status()
  File "<snip>/lib/python3.9/site-packages/requests/models.py", line 941, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://api.signalfx.com/v2/detector/validate
```

i'm sure there are other ways to accomplish this, but this 2 line change did the trick for me and doesn't change any existing behavior unless the environment variable is set. i imagine it might be useful in other cases beyond just the one i found myself stumbling over today as well.

thanks in advance for taking a look.