### PR TITLE
Ingest API to return response of POST calls

### DIFF
--- a/signalfx/ingest.py
+++ b/signalfx/ingest.py
@@ -284,6 +284,7 @@ class _BaseSignalFxIngestClient(object):
         _logger.debug('Sending to SignalFx %s (%d %s)',
                       'succeeded' if response.ok else 'failed',
                       response.status_code, response.text)
+        return response
 
 
 class ProtoBufSignalFxIngestClient(_BaseSignalFxIngestClient):


### PR DESCRIPTION
Return response code to the user when posting data using ingestion sdk.
Currently the response is not available to the user to make decisions based on the http response code.
For example, the current code will not raise an exception if the `API_TOKEN` is invalid and will give an impression that it was a successful execution. 
The status code is only visible as a debug message (`DEBUG: Sending to SignalFx failed (401 Unauthorized)`), which is not accessible in code.
```python
with signalfx.SignalFx(ingest_endpoint=SFX_INGESTION_ENDPOINT).ingest(SFX_API_TOKEN) as sfx:
    sfx.send_event(event_type='deployments')
```
With the proposed changes, this would be possible:
```python
with signalfx.SignalFx(ingest_endpoint=SFX_INGESTION_ENDPOINT).ingest(SFX_API_TOKEN) as sfx:
    response = sfx.send_event(event_type='deployments')
    if not response.ok:
        ... # deal with failures
```