### PR TITLE
Add Splunk notice to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+SignalFx was acquired by Splunk in October 2019. See https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html for more information.
+
 Python client library for SignalFx
 ==================================
 


### PR DESCRIPTION
This small PR adds the acquisition notice with a link to the README file.