### PR TITLE
fix protobuf error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi
-protobuf>=3.0.0
+protobuf==3.20.1
 pyformance>=0.3.1
 requests>=2.7.0
 sseclient-py>=1.4


### PR DESCRIPTION
This PR addresses https://github.com/signalfx/signalfx-python/issues/125 where the new version of protobuf has a bug:

```
File "/usr/local/lib/python3.10/site-packages/google/protobuf/descriptor.py", line 560, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```