### PR TITLE
Fix overstrict protobuf pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi
-protobuf==3.20.1
+protobuf>=3.0.0,<4.21.0
 pyformance>=0.3.1
 requests>=2.7.0
 sseclient-py>=1.4


### PR DESCRIPTION
The fix merged in #126, pinning `protobuf==3.20.1` conflicts with (at least) [google-api-core](https://github.com/googleapis/python-api-core/pull/459/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R33)'s recent pin on `!=3.20.1`.

The original issue, #125 , appears to only be an issue with `protobuf>=4.21.0`. This PR goes back to the old `>` pin with an additional constraint on `<4.21.0`. This should address the original issue without being unnecessarily restrictive and causing conflicts with other packages.

Exact pinning by pip packages is problematic and discouraged. In this case, it breaks our `pip-compile` workflows as no acceptable version of `protobuf` can be found.