### PR TITLE
add _pb2.py helper

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -2,7 +2,18 @@
 
 This is a guide for developing on this repository and this library. For
 instructions on how to _use_ `signalfx-python`, please refer to the
-README.md file.
+README.rst file.
+
+## Updating protobuf definitions
+
+This library uses [generated code](./signalfx/generated_protocol_buffers) from the SignalFx protobuf definitions.
+To update as necessary, from the root project directory run:
+
+```bash
+$ scripts/genproto.sh
+```
+
+And commit the updated [signal_fx_protocol_buffers_pb2.py](./signalfx/generated_protocol_buffers/signal_fx_protocol_buffers_pb2.py) after vetting the live tests with `tox`.
 
 ## Making a release
 

--- a/scripts/DOCKERFILE.genproto
+++ b/scripts/DOCKERFILE.genproto
@@ -1,0 +1,13 @@
+FROM debian:buster
+
+ARG PROTOC_VERSION=3.5.1
+
+RUN mkdir -p /usr/src/signalfx-python/
+WORKDIR /tmp
+
+RUN apt-get update && apt-get install wget unzip -y
+RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip && \
+    unzip protoc*.zip -d protoc
+
+RUN wget https://raw.githubusercontent.com/signalfx/signalfx-java/main/signalfx-protoc/src/main/protobuf/signal_fx_protocol_buffers.proto
+RUN protoc/bin/protoc signal_fx_protocol_buffers.proto --python_out /usr/src/signalfx-python

--- a/scripts/genproto.sh
+++ b/scripts/genproto.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set +ex
+
+project_dir="$(dirname "${BASH_SOURCE[0]}")/.."
+cd $project_dir
+docker build --build-arg PROTOC_VERSION=3.5.1 -f scripts/DOCKERFILE.genproto -t signalfx-python-genproto .
+docker run signalfx-python-genproto cat /usr/src/signalfx-python/signal_fx_protocol_buffers_pb2.py > signalfx/generated_protocol_buffers/signal_fx_protocol_buffers_pb2.py

--- a/signalfx/rest.py
+++ b/signalfx/rest.py
@@ -367,8 +367,8 @@ class SignalFxRestClient(object):
         return resp
 
     def get_dashboard_groups(self, name=None, batch_size=100, **kwargs):
-        """Retrieve all (v2) dashboard groupss matching the given name; all (v2)
-        dashboard groups otherwise.
+        """Retrieve all (v2) dashboard groupss matching the given name;
+        all (v2) dashboard groups otherwise.
 
         Note that this method will loop through the paging of the results and
         accumulate all dashboard groups that match the query.


### PR DESCRIPTION
These changes add a new `genproto.sh` script and associated docker image for generating python code from the SFx proto definitions. They target an older version of protoc so that the resulting _pb2.py is unchanged but can be helpful for future maintenance.

Also including a lint fix.