### PR TITLE
POST call return error if API token is invalid

### DIFF
--- a/tests/test_data_reporting.py
+++ b/tests/test_data_reporting.py
@@ -18,7 +18,7 @@ if args.token == "invalid":
 else:
     MY_TOKEN = os.environ['SIGNALFX_API_TOKEN']
 sfx = signalfx.SignalFx().ingest(MY_TOKEN)
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 # Basic Usage
 sfx.send(

--- a/tests/test_data_reporting.py
+++ b/tests/test_data_reporting.py
@@ -7,11 +7,18 @@ import os
 import sys
 import signalfx
 import time
+import argparse
 
+parser = argparse.ArgumentParser()
+parser.add_argument("--token", choices=["valid", "invalid"], default="valid", type=str, help="Provider Name")
+args = parser.parse_args()
 
-MY_TOKEN = os.environ['SIGNALFX_API_TOKEN']
+if args.token == "invalid":
+    MY_TOKEN = "123-12345678-123456789"
+else:
+    MY_TOKEN = os.environ['SIGNALFX_API_TOKEN']
 sfx = signalfx.SignalFx().ingest(MY_TOKEN)
-logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 # Basic Usage
 sfx.send(
@@ -44,7 +51,7 @@ sfx.send(
 
 # Sending events
 sfx.send_event(
-        event_type='deployments',
+        event_type='deployments_test',
         category='USER_DEFINED',
         dimensions={
             'host': 'myhost',


### PR DESCRIPTION
This change will return an error in case the user's API TOKEN is invalid or the authentication didn't go through. 
Currently, the user receives no response if the API TOKEN is invalid. This might mislead the user into thinking everything went well when it doesn't.

In previous attempts to add this minor fix, a test was required. So I also added a validation test to the `test_data_reporting` file to check if we indeed receive an error, and this is the output we will get in case of an invalid token:
```
ERROR:root:401 Client Error: Unauthorized for url: https://ingest.signalfx.com/v2/event
ERROR:root:401 Client Error: Unauthorized for url: https://ingest.signalfx.com/v2/datapoint
ERROR:root:401 Client Error: Unauthorized for url: https://ingest.signalfx.com/v2/datapoint
```
Let me know if something else is required.